### PR TITLE
feat: sanitize transcript appendices

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Important settings in `config/settings.json`:
 - `weekly_resource_limit`: maximum resources in the weekly book
 - `max_items_per_run`: optional cost/safety cap; `0` means no cap
 - `kindle_output_format`: `epub` or `markdown`
+- `rewrite_full_transcripts`: when full transcripts are included, also rewrite cleaned transcript text with Mistral for readability
 
 Per-source settings in `config/sources.json`:
 

--- a/config/settings.example.json
+++ b/config/settings.example.json
@@ -8,6 +8,8 @@
   "transcription_provider": "mistral",
   "transcription_model": "voxtral-mini-latest",
   "include_full_transcripts": false,
+  "rewrite_full_transcripts": false,
+  "transcript_rewrite_model": "mistral-small-latest",
   "kindle_output_format": "epub",
   "weekly_resource_limit": 30,
   "publication_window_days": 7,

--- a/scripts/check_repo_health.py
+++ b/scripts/check_repo_health.py
@@ -87,6 +87,8 @@ def _check_settings(path: Path, errors: list[str]) -> None:
         errors.append(f"{label}: summary_model must not be empty.")
     if not str(settings.summary_fallback_model or "").strip():
         errors.append(f"{label}: summary_fallback_model must not be empty.")
+    if settings.rewrite_full_transcripts and not str(settings.transcript_rewrite_model or "").strip():
+        errors.append(f"{label}: transcript_rewrite_model must not be empty when rewrite_full_transcripts is enabled.")
     if settings.transcription_provider not in {"mistral", "none"}:
         errors.append(f"{label}: transcription_provider must be 'mistral' or 'none'.")
     if settings.kindle_output_format.lower() not in {"epub", "markdown", "md"}:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -20,6 +20,8 @@ class Settings:
     transcription_provider: str
     transcription_model: str
     include_full_transcripts: bool
+    rewrite_full_transcripts: bool
+    transcript_rewrite_model: str
     kindle_output_format: str
     weekly_resource_limit: int
     publication_window_days: int
@@ -48,6 +50,8 @@ def load_settings(path: Path | None = None) -> Settings:
         transcription_provider=raw.get("transcription_provider", "mistral"),
         transcription_model=raw.get("transcription_model", "voxtral-mini-latest"),
         include_full_transcripts=raw.get("include_full_transcripts", False),
+        rewrite_full_transcripts=raw.get("rewrite_full_transcripts", False),
+        transcript_rewrite_model=raw.get("transcript_rewrite_model", raw.get("summary_model", "mistral-small-latest")),
         kindle_output_format=raw.get("kindle_output_format", "epub"),
         weekly_resource_limit=int(raw.get("weekly_resource_limit", 25)),
         publication_window_days=int(raw.get("publication_window_days", 7)),

--- a/scripts/digest.py
+++ b/scripts/digest.py
@@ -8,6 +8,7 @@ from obsidian_graph import weekly_resource_links
 from public_epub import public_epub_markdown_url
 from project_paths import OUTPUT, PUBLIC_LATEST_MD, PUBLIC_WEEKLY, WEEKLY_BOOKS
 from summary_metadata import featured_speakers, without_featured_speakers
+from transcript_sanitizer import transcript_for_reading
 from utils import parse_date, read_text, split_frontmatter, strip_graph_only_sections, today_stamp, write_text, yaml_value
 
 
@@ -63,7 +64,7 @@ def build_digest(
             resource = read_text(resource_path)
             lines.append(f"## {_resource_title(resource_path)} ({_resource_date(resource_path)})")
             lines.append("")
-            lines.append(_transcript_part(resource).strip())
+            lines.append(transcript_for_reading(_transcript_part(resource), settings).strip())
             lines.append("")
             lines.append("***")
             lines.append("")

--- a/scripts/project_paths.py
+++ b/scripts/project_paths.py
@@ -28,6 +28,7 @@ TEMPLATES = KNOWLEDGE_BASE / "templates"
 SUMMARIES = OUTPUT / "_summaries"
 MEDIA = OUTPUT / "_media"
 METADATA = OUTPUT / "_metadata"
+SANITIZED_TRANSCRIPTS = OUTPUT / "_sanitized_transcripts"
 
 
 def ensure_dirs() -> None:
@@ -52,5 +53,6 @@ def ensure_dirs() -> None:
         INDEXES,
         TEMPLATES,
         METADATA,
+        SANITIZED_TRANSCRIPTS,
     ):
         path.mkdir(parents=True, exist_ok=True)

--- a/scripts/test_transcript_sanitizer.py
+++ b/scripts/test_transcript_sanitizer.py
@@ -18,6 +18,44 @@ def test_deterministic_cleanup_structures_transcript() -> None:
     assert "**Alice:** this has spacing." in cleaned
 
 
+def test_deterministic_cleanup_keeps_wrapped_lines_with_same_speaker() -> None:
+    raw = """Speaker_1: first thought here
+this line wraps the same speaker and should stay attributed.
+
+Speaker_2: response starts here
+and continues on the next line too."""
+
+    cleaned = transcript_sanitizer.deterministic_cleanup(raw)
+
+    assert "**Speaker 1:** first thought here this line wraps the same speaker and should stay attributed." in cleaned
+    assert "**Speaker 2:** response starts here and continues on the next line too." in cleaned
+
+
+def test_rewrite_flag_does_not_depend_on_summary_provider() -> None:
+    original_rewrite = transcript_sanitizer._cached_mistral_rewrite
+    original_key = os.environ.get("MISTRAL_API_KEY")
+    os.environ["MISTRAL_API_KEY"] = "test-key"
+    transcript_sanitizer._cached_mistral_rewrite = lambda cleaned, _settings: f"rewritten::{cleaned}"
+    try:
+        result = transcript_sanitizer.transcript_for_reading(
+            "Speaker_1: raw words here.",
+            SimpleNamespace(
+                rewrite_full_transcripts=True,
+                summary_provider="local",
+                transcript_rewrite_model="mistral-small-latest",
+            ),
+        )
+    finally:
+        transcript_sanitizer._cached_mistral_rewrite = original_rewrite
+        if original_key is None:
+            os.environ.pop("MISTRAL_API_KEY", None)
+        else:
+            os.environ["MISTRAL_API_KEY"] = original_key
+
+    assert result.startswith("rewritten::")
+    assert "**Speaker 1:** raw words here." in result
+
+
 def test_mistral_prompt_targets_spoken_word_artifacts() -> None:
     captured = {}
 
@@ -65,6 +103,8 @@ def _settings() -> SimpleNamespace:
 
 def main() -> None:
     test_deterministic_cleanup_structures_transcript()
+    test_deterministic_cleanup_keeps_wrapped_lines_with_same_speaker()
+    test_rewrite_flag_does_not_depend_on_summary_provider()
     test_mistral_prompt_targets_spoken_word_artifacts()
 
 

--- a/scripts/test_transcript_sanitizer.py
+++ b/scripts/test_transcript_sanitizer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+
+import transcript_sanitizer
+
+
+def test_deterministic_cleanup_structures_transcript() -> None:
+    raw = """[00:01] Speaker_1: um this is raw.\n\n00:02:03\nAlice: this has spacing."""
+
+    cleaned = transcript_sanitizer.deterministic_cleanup(raw)
+
+    assert "[00:01]" not in cleaned
+    assert "00:02:03" not in cleaned
+    assert "**Speaker 1:** um this is raw." in cleaned
+    assert "**Alice:** this has spacing." in cleaned
+
+
+def test_mistral_prompt_targets_spoken_word_artifacts() -> None:
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return {"choices": [{"message": {"content": "**Speaker 1:** This is cleaner."}}]}
+
+    def post(_url: str, *, headers: dict, json: dict, timeout: int) -> FakeResponse:
+        captured["payload"] = json
+        return FakeResponse()
+
+    original_requests = sys.modules.get("requests")
+    original_key = os.environ.get("MISTRAL_API_KEY")
+    fake_requests = ModuleType("requests")
+    setattr(fake_requests, "post", post)
+    sys.modules["requests"] = fake_requests
+    os.environ["MISTRAL_API_KEY"] = "test-key"
+    try:
+        result = transcript_sanitizer._rewrite_chunk("**Speaker 1:** um I I think this matters.", _settings())
+    finally:
+        if original_requests is None:
+            sys.modules.pop("requests", None)
+        else:
+            sys.modules["requests"] = original_requests
+        if original_key is None:
+            os.environ.pop("MISTRAL_API_KEY", None)
+        else:
+            os.environ["MISTRAL_API_KEY"] = original_key
+
+    prompt = "\n".join(message["content"] for message in captured["payload"]["messages"]).lower()
+    assert result == "**Speaker 1:** This is cleaner."
+    assert "lexical fillers" in prompt
+    assert "false starts" in prompt
+    assert "repeated words" in prompt
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(transcript_rewrite_model="mistral-small-latest")
+
+
+def main() -> None:
+    test_deterministic_cleanup_structures_transcript()
+    test_mistral_prompt_targets_spoken_word_artifacts()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/transcript_sanitizer.py
+++ b/scripts/transcript_sanitizer.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import time
+
+from config import Settings
+from project_paths import SANITIZED_TRANSCRIPTS
+
+
+CHUNK_SIZE = 12000
+
+
+def transcript_for_reading(transcript: str, settings: Settings) -> str:
+    cleaned = deterministic_cleanup(transcript)
+    if not settings.rewrite_full_transcripts:
+        return cleaned
+    if settings.summary_provider != "mistral" or not os.environ.get("MISTRAL_API_KEY"):
+        return cleaned
+    return _cached_mistral_rewrite(cleaned, settings)
+
+
+def deterministic_cleanup(transcript: str) -> str:
+    text = transcript.replace("\r\n", "\n").replace("\r", "\n")
+    paragraphs: list[str] = []
+    pending: list[str] = []
+
+    def flush_pending() -> None:
+        if not pending:
+            return
+        paragraphs.extend(_paragraphs_from_text(" ".join(pending)))
+        pending.clear()
+
+    for raw_line in text.splitlines():
+        line = _clean_line(raw_line)
+        if not line:
+            flush_pending()
+            continue
+        speaker, rest = _speaker_turn(line)
+        if speaker:
+            flush_pending()
+            paragraphs.append(f"**{speaker}:** {rest}" if rest else f"**{speaker}:**")
+            continue
+        pending.append(line)
+    flush_pending()
+    return "\n\n".join(paragraphs).strip()
+
+
+def _clean_line(line: str) -> str:
+    line = re.sub(r"\s+", " ", line).strip()
+    line = re.sub(r"^(?:\[?\d{1,2}:\d{2}(?::\d{2})?\]?\s*)+", "", line).strip()
+    if re.fullmatch(r"\[?\d{1,2}:\d{2}(?::\d{2})?\]?", line):
+        return ""
+    return line
+
+
+def _speaker_turn(line: str) -> tuple[str | None, str]:
+    match = re.match(
+        r"^(?:[-*]\s*)?((?:speaker|SPEAKER)[_ -]?\d{1,2}|[A-Za-z][A-Za-z0-9 ._'-]{0,50})\s*:\s*(.*)$",
+        line,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None, line
+    speaker = re.sub(r"\s+", " ", match.group(1).replace("_", " ")).strip()
+    if len(speaker.split()) > 6:
+        return None, line
+    return speaker, match.group(2).strip()
+
+
+def _paragraphs_from_text(text: str) -> list[str]:
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    paragraphs: list[str] = []
+    current: list[str] = []
+    word_count = 0
+    for sentence in sentences:
+        words = sentence.split()
+        if current and word_count + len(words) > 120:
+            paragraphs.append(" ".join(current))
+            current = []
+            word_count = 0
+        current.append(sentence)
+        word_count += len(words)
+    if current:
+        paragraphs.append(" ".join(current))
+    return paragraphs
+
+
+def _cached_mistral_rewrite(transcript: str, settings: Settings) -> str:
+    SANITIZED_TRANSCRIPTS.mkdir(parents=True, exist_ok=True)
+    key = hashlib.sha256(f"{settings.transcript_rewrite_model}\n{transcript}".encode("utf-8")).hexdigest()
+    cache_path = SANITIZED_TRANSCRIPTS / f"{key}.md"
+    if cache_path.exists():
+        return cache_path.read_text(encoding="utf-8").strip()
+    try:
+        rewritten = "\n\n".join(_rewrite_chunk(chunk, settings) for chunk in _chunks(transcript)).strip()
+    except Exception as exc:
+        print(f"Mistral transcript rewrite failed; using deterministic cleanup: {exc}")
+        return transcript
+    if rewritten:
+        cache_path.write_text(rewritten + "\n", encoding="utf-8")
+        return rewritten
+    return transcript
+
+
+def _chunks(text: str) -> list[str]:
+    chunks: list[str] = []
+    current = ""
+    for paragraph in text.split("\n\n"):
+        addition = paragraph if not current else f"{current}\n\n{paragraph}"
+        if len(addition) > CHUNK_SIZE and current:
+            chunks.append(current)
+            current = paragraph
+        else:
+            current = addition
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _rewrite_chunk(chunk: str, settings: Settings) -> str:
+    import requests
+
+    headers = {
+        "Authorization": f"Bearer {os.environ['MISTRAL_API_KEY']}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": settings.transcript_rewrite_model,
+        "temperature": 0.1,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Rewrite transcripts into readable Markdown while preserving meaning, speaker turns, names, and factual claims. Do not summarize or add information.",
+            },
+            {
+                "role": "user",
+                "content": f"Clean this transcript excerpt for reading. Keep speaker labels in bold Markdown when present. Remove filler only when it does not change meaning. Return only the cleaned transcript.\n\n{chunk}",
+            },
+        ],
+    }
+    response = None
+    for delay in (0, 10, 30):
+        if delay:
+            print(f"Mistral transcript rewrite backoff: waiting {delay}s")
+            time.sleep(delay)
+        response = requests.post(
+            "https://api.mistral.ai/v1/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=120,
+        )
+        if response.status_code != 429:
+            response.raise_for_status()
+            return _strip_markdown_fence(response.json()["choices"][0]["message"]["content"])
+    assert response is not None
+    response.raise_for_status()
+    return ""
+
+
+def _strip_markdown_fence(content: str) -> str:
+    stripped = content.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.splitlines()
+    if len(lines) >= 2 and lines[-1].strip() == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return stripped
+
+
+def _demo() -> None:
+    raw = """[00:01] Speaker_1: um this is a raw line. it keeps going because transcripts are messy.\n\n00:02:03\nAlice: I think this should read better. You know, without weird spacing."""
+    cleaned = deterministic_cleanup(raw)
+    assert "[00:01]" not in cleaned
+    assert "**Speaker 1:**" in cleaned
+    assert "**Alice:**" in cleaned
+
+
+if __name__ == "__main__":
+    _demo()

--- a/scripts/transcript_sanitizer.py
+++ b/scripts/transcript_sanitizer.py
@@ -16,7 +16,7 @@ def transcript_for_reading(transcript: str, settings: Settings) -> str:
     cleaned = deterministic_cleanup(transcript)
     if not settings.rewrite_full_transcripts:
         return cleaned
-    if settings.summary_provider != "mistral" or not os.environ.get("MISTRAL_API_KEY"):
+    if not os.environ.get("MISTRAL_API_KEY"):
         return cleaned
     return _cached_mistral_rewrite(cleaned, settings)
 
@@ -25,22 +25,31 @@ def deterministic_cleanup(transcript: str) -> str:
     text = transcript.replace("\r\n", "\n").replace("\r", "\n")
     paragraphs: list[str] = []
     pending: list[str] = []
+    current_speaker: str | None = None
 
     def flush_pending() -> None:
+        nonlocal current_speaker
         if not pending:
             return
-        paragraphs.extend(_paragraphs_from_text(" ".join(pending)))
+        rendered = _paragraphs_from_text(" ".join(pending))
+        if current_speaker:
+            paragraphs.extend(f"**{current_speaker}:** {paragraph}" for paragraph in rendered)
+        else:
+            paragraphs.extend(rendered)
         pending.clear()
 
     for raw_line in text.splitlines():
         line = _clean_line(raw_line)
         if not line:
             flush_pending()
+            current_speaker = None
             continue
         speaker, rest = _speaker_turn(line)
         if speaker:
             flush_pending()
-            paragraphs.append(f"**{speaker}:** {rest}" if rest else f"**{speaker}:**")
+            current_speaker = speaker
+            if rest:
+                pending.append(rest)
             continue
         pending.append(line)
     flush_pending()
@@ -70,6 +79,8 @@ def _speaker_turn(line: str) -> tuple[str | None, str]:
 
 
 def _paragraphs_from_text(text: str) -> list[str]:
+    if not text.strip():
+        return []
     sentences = re.split(r"(?<=[.!?])\s+", text.strip())
     paragraphs: list[str] = []
     current: list[str] = []

--- a/scripts/transcript_sanitizer.py
+++ b/scripts/transcript_sanitizer.py
@@ -132,11 +132,11 @@ def _rewrite_chunk(chunk: str, settings: Settings) -> str:
         "messages": [
             {
                 "role": "system",
-                "content": "Rewrite transcripts into readable Markdown while preserving meaning, speaker turns, names, and factual claims. Do not summarize or add information.",
+                "content": "Rewrite transcripts into readable Markdown while preserving meaning, speaker turns, names, and factual claims. Remove lexical fillers, smooth false starts, and collapse repeated words only when they do not change meaning. Do not summarize or add information.",
             },
             {
                 "role": "user",
-                "content": f"Clean this transcript excerpt for reading. Keep speaker labels in bold Markdown when present. Remove filler only when it does not change meaning. Return only the cleaned transcript.\n\n{chunk}",
+                "content": f"Clean this transcript excerpt for reading. Keep speaker labels in bold Markdown when present. Remove lexical fillers such as um, uh, you know, and non-meaningful like. Smooth false starts and repeated words. Preserve technical terms, claims, numbers, caveats, and speaker intent. Return only the cleaned transcript.\n\n{chunk}",
             },
         ],
     }

--- a/skills/ai-weekly-reads/SKILL.md
+++ b/skills/ai-weekly-reads/SKILL.md
@@ -68,6 +68,7 @@ Each run checks the configured source inspection windows, filters recurring sour
 - If Mail has no configured accounts, delivery is skipped and should not be recorded as sent.
 - Successful sends are recorded in `output/_metadata/kindle_delivery.json`; do not resend the same digest unless the user asks for `--force`.
 - Setting `send_to_kindle: false` on a resource note excludes it from the generated weekly book entirely — the digest, public editions, EPUB, and Substack export all build from the same book. Excluded notes are logged during the build.
+- Full transcript appendices are deterministically cleaned for reading before EPUB generation. `rewrite_full_transcripts: true` additionally runs a cached Mistral rewrite; raw transcripts remain unchanged.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Full transcript appendices can now be made readable before EPUB generation instead of shipping raw transcript blobs unchanged. The build first applies deterministic structure cleanup, then optionally runs a cached Mistral rewrite when `rewrite_full_transcripts` is enabled.

Raw transcript archives remain untouched, and LLM rewriting is opt-in so existing builds do not incur surprise API calls.

## Test Plan

- `python3 scripts/test_transcript_sanitizer.py`
- `python3 scripts/transcript_sanitizer.py`
- `find scripts -name '*.py' -print0 | xargs -0 python3 -m py_compile`
- `python3 scripts/check_repo_health.py`
- `git diff --check`

`python3 scripts/audit_knowledge_base.py` was not runnable in this checkout because `requests` is not installed for the existing `scripts/summarize.py` import path.
