### PR TITLE
Make the Substack draft script safe to run unattended

### DIFF
--- a/.github/workflows/substack-draft.yml
+++ b/.github/workflows/substack-draft.yml
@@ -91,13 +91,18 @@ jobs:
           fi
           python scripts/create_substack_draft.py --headless
 
-      - name: Upload the post as an artifact
+      - name: Upload the post and any diagnostics
         # Runs even when drafting fails, so the post is still retrievable and
-        # can be pasted by hand.
+        # can be pasted by hand. On failure this also carries the screenshot and
+        # page HTML captured by the script, which is the only way to tell a
+        # stale selector apart from an expired session.
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: substack-post
-          path: output/substack/*.md
+          path: |
+            output/substack/*.md
+            output/substack/diagnostic-*.png
+            output/substack/diagnostic-*.html
           if-no-files-found: warn
           retention-days: 14

--- a/scripts/create_substack_draft.py
+++ b/scripts/create_substack_draft.py
@@ -20,6 +20,44 @@ REQUIRED_MARKERS = ("## Contents", "## Reading Notes")
 DATE_MARKERS = ("- **Published:**", "- **Added:**")
 
 
+def _interactive() -> bool:
+    """True when a human is at a terminal who can take over the browser."""
+    return sys.stdin.isatty() and not os.environ.get("SUBSTACK_SID", "").strip()
+
+
+def _prompt_human(message: str) -> None:
+    """Hand control to the operator, or fail loudly when nobody is watching.
+
+    Every manual fallback in this script assumes someone can click in the
+    browser. Unattended (CI), that assumption is false: prompting there would
+    hang until the job timed out, so stop with a message that names the step.
+    """
+    if not _interactive():
+        raise SystemExit(f"Cannot continue without a human: {message}")
+    input(message)
+
+
+def _dump_diagnostics(page, label: str) -> None:
+    """Save what the browser actually saw, so an unattended failure is debuggable.
+
+    The artifact upload collects these, which is the only way to tell a stale
+    selector apart from a session that was silently signed out.
+    """
+    try:
+        target = OUTPUT / "substack"
+        target.mkdir(parents=True, exist_ok=True)
+        print(f"Diagnostics [{label}]: url={page.url}")
+        try:
+            print(f"Diagnostics [{label}]: title={page.title()!r}")
+        except Exception:
+            pass
+        page.screenshot(path=str(target / f"diagnostic-{label}.png"), full_page=True)
+        (target / f"diagnostic-{label}.html").write_text(page.content(), encoding="utf-8")
+        print(f"Diagnostics [{label}]: screenshot and HTML saved under {target}")
+    except Exception as exc:
+        print(f"Diagnostics [{label}] could not be captured: {exc}")
+
+
 @dataclass(frozen=True)
 class DraftPost:
     title: str
@@ -205,8 +243,7 @@ def _create_browser_draft(draft: DraftPost, settings: Settings, *, setup_only: b
 
         page.goto(compose_url, wait_until="domcontentloaded", timeout=60_000)
         if setup_only:
-            print("Log into Substack in the browser window, then press Enter here to save the session.")
-            input()
+            _prompt_human("Log into Substack in the browser window, then press Enter here to save the session.")
             context.close()
             print(f"Substack browser session saved under {user_data_dir}.")
             return
@@ -234,15 +271,18 @@ def _maybe_wait_for_login(page, compose_url: str, timeout_error_type) -> None:
     if _editor_is_visible(page, timeout_error_type, timeout=5_000):
         return
     if not _looks_like_login_gate(page):
+        # Neither a usable editor nor a recognizable login page. That is either
+        # a signed-out state this heuristic does not match or a Substack
+        # redesign, and the two are indistinguishable from the logs alone.
+        _dump_diagnostics(page, "editor-missing")
         return
 
+    _dump_diagnostics(page, "login-gate")
     print("Substack needs you to log in or confirm this browser session.")
-    print("Complete that in the browser, then press Enter here.")
-    input()
+    _prompt_human("Complete that in the browser, then press Enter here.")
     page.goto(compose_url, wait_until="domcontentloaded", timeout=60_000)
     if not _editor_is_visible(page, timeout_error_type, timeout=15_000) and _looks_like_login_gate(page):
-        print("Substack still looks signed out. Complete the login, then press Enter here.")
-        input()
+        _prompt_human("Substack still looks signed out. Complete the login, then press Enter here.")
         page.goto(compose_url, wait_until="domcontentloaded", timeout=60_000)
 
 
@@ -269,7 +309,8 @@ def _fill_title(page, title: str, timeout_error_type) -> None:
             continue
     print("I could not find the title field automatically.")
     print(f"Title to paste manually: {title}")
-    input("Click the Substack title field, paste/type the title, then press Enter here...")
+    _dump_diagnostics(page, "title-field-missing")
+    _prompt_human("Click the Substack title field, paste/type the title, then press Enter here...")
 
 
 def _fill_subtitle(page, subtitle: str, timeout_error_type) -> None:
@@ -320,7 +361,8 @@ def _paste_body(page, draft: DraftPost, timeout_error_type) -> None:
         except Exception:
             continue
     print("Substack did not expose a stable body editor selector, but the full post is on the browser clipboard.")
-    input("Click the Substack body editor, paste, then press Enter here...")
+    _dump_diagnostics(page, "body-editor-missing")
+    _prompt_human("Click the Substack body editor, paste, then press Enter here...")
 
 
 def _publish_post(page, timeout_error_type) -> None:


### PR DESCRIPTION
The first CI run of the Substack draft workflow failed with `EOFError`.

## Cause

`create_substack_draft.py` contains six interactive `input()` prompts used as manual fallbacks — the script was written for a human sitting in front of a browser. Only one was guarded for unattended use. When the title selector failed to match, the script asked a human to paste the title by hand and there was nobody attached to stdin.

## Changes

- Every prompt now goes through a helper that raises with a message naming the step when no terminal is attached, instead of hanging until the job times out. The local interactive path is unchanged.
- On a selector miss or a missing editor, capture a screenshot and the page HTML and upload them as artifacts.

The diagnostics matter for the open question: the run could not distinguish an expired session from stale selectors, because the login-gate check is a heuristic and did not fire. The screenshot settles which it is.

## Verification

Compiles and passes pyflakes. Confirmed the helper raises rather than prompting when `SUBSTACK_SID` is set, and still prompts normally when attached to a terminal.

The workflow continues to create a draft only, never publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011DYabtucPQzJ5n1ULQoX5A)_