### PR TITLE
Stop losing failed items, point at the renamed KB, drop the browser Substack path

### DIFF
--- a/skills/ai-weekly-reads/SKILL.md
+++ b/skills/ai-weekly-reads/SKILL.md
@@ -35,7 +35,18 @@ Work from the AI Weekly Reads repository root.
 
 The knowledge base persists across ephemeral cloud sessions in the private repo `sophiamyang/ai-weekly-reads-kb`, nested as a second git repo at `knowledge_base/.git` inside this checkout. The main repo keeps tracking `knowledge_base/Home.md`, `README.md`, and `templates/`; the KB repo tracks the generated stores (`raw_transcripts/`, `resources/`, `weekly_books/`, `sources/`, `people/`, `topics/`, `indexes/`) and ignores the main-repo-owned files via its own `.gitignore`.
 
-- At session start (if the environment setup script has not already done it): attach `sophiamyang/ai-weekly-reads-kb` with push access, then from the checkout root run `git clone https://github.com/sophiamyang/ai-weekly-reads-kb /tmp/kb && mv /tmp/kb/.git knowledge_base/.git && rm -rf /tmp/kb && git -C knowledge_base checkout -- .` to restore prior state so already-processed items are skipped.
+- At session start (if the environment setup script has not already done it): attach `sophiamyang/ai-weekly-reads-kb` with push access, then from the checkout root run:
+
+  ```bash
+  git clone https://github.com/sophiamyang/ai-weekly-reads-kb /tmp/kb && \
+    mv /tmp/kb/.git knowledge_base/.git && rm -rf /tmp/kb && \
+    git -C knowledge_base checkout -- .
+  git -C knowledge_base config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' && \
+    git -C knowledge_base fetch origin
+  ```
+
+  The second command asserts the fetch refspec. A plain clone sets it, but a `.git` assembled any other way (`init` + `remote add` + `pull`) leaves it unset, and then `origin/main` never exists: `git status` cannot report ahead/behind and the only way to tell whether the KB is pushed is `git ls-remote`. It is idempotent, so run it unconditionally.
+- Verify the restore before processing anything: `git -C knowledge_base status -sb` should print `## main...origin/main`, and `knowledge_base/resources/` should already be populated. An empty `resources/` means the restore failed, and the run will re-transcribe everything it has already done — burning the Gemini daily quota and the caption rate limit for nothing.
 - After a successful weekly run: commit and push `knowledge_base/` to the KB repo's `main` branch (message like "Weekly knowledge-base update YYYY-MM-DD") in addition to the normal public-edition commit in the main repo.
 - The KB repo must stay private: `raw_transcripts/` holds verbatim third-party content that must never be published in the public repo or editions.
 


### PR DESCRIPTION
Four changes, most significant first.

## 1. Items that never produced a transcript were being lost silently

A discovered item whose transcription failed was recorded only in `output/_metadata/last_run.json` — gitignored, overwritten every run, and gone when an ephemeral container is reclaimed. Once the publication window moved past it, it was never rediscovered either. No error, no record.

**Four items from the 2026-08-29 run are already gone this way.** They were found by cross-referencing that file against the vault; the audit reported no issues at the time.

Adds a durable ledger in the knowledge base. Failures are recorded, cleared when the item later succeeds, and retried on subsequent runs ignoring the publication window — the window having moved is precisely the problem.

Bounded in both directions:

| Bound | Reason |
|---|---|
| `MAX_RETRIES_PER_RUN` (10), oldest first | Retries compete with new content for the same daily Gemini quota |
| `MAX_ATTEMPTS` (4), then abandoned | Reported in the audit, not retried forever |

The audit now reports outstanding and abandoned counts, so a clean audit means nothing was dropped rather than only that the notes are well formed. The four known-lost items are seeded in and will be retried.

The ledger is gitignored here and tracked by the private KB repo. Item descriptions are third-party text and are excluded from it.

## 2. The knowledge base repo was renamed and is now shared

`sophiamyang/ai-weekly-reads-kb` → `sophiamyang/ai-knowledge-base`. It is no longer state belonging to this pipeline: other workflows publish into the same vault, so its note schema is a contract (documented in that repo's `KB_README.md`) and this pipeline must not assume every note there came from it.

## 3. The KB restore was not verifiable

The nested KB repo had no `remote.origin.fetch`, so `origin/main` never existed. Push and pull worked, but `git status` could not report ahead/behind and confirming a push required `git ls-remote`. A plain clone sets the refspec; a `.git` assembled by `init` + `remote add` + `pull` does not, which is how this one came to be.

Asserts it during restore, and adds a pre-run verification step — a silently failed restore leaves `resources/` empty, so the run re-transcribes the entire backlog, spending the Gemini quota and re-triggering the caption rate limit on work already done.

## 4. Removes the browser-based Substack draft path

`scripts/create_substack_draft.py` (518 lines) was superseded by `post_to_substack.py`. Nothing invoked it, nothing imported it, and it cannot run in the weekly cloud session: it needs a residential IP, a second virtualenv, and an interactive login.

It was not a real fallback either — an expired cookie breaks the API and browser paths alike, and recovering either means logging in by hand, at which point pasting the emailed post is shorter. That email fallback already exists and stays.

`playwright` and `markdown` were used by no other script, so `requirements-substack.txt` is now just `python-substack`. The Saturday routine installs that file weekly, and playwright alone is 137 MB.

## Verification

- Retry injection tested through the real `discover_items`: all four ledger items entered discovery ahead of normal resolution.
- Ledger lifecycle tested: attempt accumulation, retry cutoff, per-run cap, clearing on success, and safe degradation on a missing or malformed file.
- Full compile, pyflakes, `check_repo_health.py`, and `audit_knowledge_base.py` pass.
- `post_to_substack.py` still imports and exposes its entrypoints after the removal.

## Outside this repo

- `KB_README.md` in the private KB repo, rewritten as a publishing contract; the ledger's first four entries are committed there.
- The Saturday routine, updated for the new repo name, the refspec, restore verification, and a pull-before-push note for the shared generated hubs.
