### PR TITLE
Reflow raw transcripts, run tests in CI, and detect truncated transcripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,18 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Compile Python scripts
         run: find scripts -name '*.py' -print0 | xargs -0 python -m py_compile
+
+      - name: Lint
+        run: python -m pyflakes scripts
+
+      # These tests existed but nothing ran them, so a regression in transcript
+      # handling could reach the knowledge base unnoticed.
+      - name: Run tests
+        run: PYTHONPATH=scripts python -m pytest scripts -q
 
       - name: Check repo health
         run: python scripts/check_repo_health.py

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The summary and output stage is identical after that point. Both source types en
 - `output/substack/latest.md`: current Substack-ready post
 - `knowledge_base/resources/`: local clean reading notes for Obsidian
 - `knowledge_base/raw_transcripts/`: local raw transcript/text archive
+- `scripts/reformat_raw_transcripts.py`: reflow stored transcripts into readable paragraphs (no text changes)
 - `knowledge_base/unresolved.json`: items discovered but not yet transcribed, retried on later runs
 
 ## Weekly Run

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pyflakes>=3.0

--- a/scripts/audit_knowledge_base.py
+++ b/scripts/audit_knowledge_base.py
@@ -45,7 +45,7 @@ def main() -> None:
         if fields.get("raw_transcript") and not _raw_transcript_link_exists(str(fields.get("raw_transcript")))
     ]
     placeholders = [path for path in resource_paths if _has_placeholder(path)]
-    short_transcripts = [path for path in transcript_paths if len(read_transcript_text(path).split()) < 250]
+    short_transcripts = [path for path in transcript_paths if _looks_incomplete(read_transcript_text(path))]
     metadata_issues = _metadata_issues(resource_paths, transcript_paths, weekly_books)
     graph_issues = _graph_issues(resource_paths, weekly_books)
 
@@ -73,7 +73,7 @@ def main() -> None:
     _print_paths("Resources missing raw transcripts", missing_raw)
     _print_paths("Resources with broken raw transcript links", broken_raw_links)
     _print_paths("Resources with placeholder summaries", placeholders)
-    _print_paths("Very short raw transcripts", short_transcripts)
+    _print_paths("Truncated or stub raw transcripts", short_transcripts)
     _print_issues("Obsidian metadata issues", metadata_issues)
     _print_issues("Obsidian graph issues", graph_issues)
     if not any(
@@ -91,6 +91,35 @@ def main() -> None:
         ]
     ):
         print("No audit issues found.")
+
+
+# A short transcript is not the same as a broken one. Publishers post genuine
+# 1-2 minute clips: two Stanford Online overviews here run 1m12s and 1m33s and
+# transcribe to 180 and 194 words, which is 125-150 words per minute — a normal
+# speaking pace and a complete transcript. Flagging those every week trains the
+# reader to ignore the audit, which costs more than the check is worth.
+#
+# Flag instead what actually indicates a problem: a stub too short to be any
+# real item, or text that stops mid-sentence, which is what truncation looks
+# like.
+STUB_TRANSCRIPT_WORDS = 60
+_SENTENCE_ENDINGS = '.?!"\')]’”'
+
+
+def _looks_incomplete(text: str) -> bool:
+    """A stub, or text that stops mid-sentence.
+
+    Length alone was the wrong signal in both directions. It flagged two
+    complete 1-2 minute clips every run, and it missed five transcripts of
+    1,800-4,300 words that simply stop mid-sentence ("...thanks for being here
+    and"), which is what a cut-off transcription actually looks like.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return True
+    if len(stripped.split()) < STUB_TRANSCRIPT_WORDS:
+        return True
+    return stripped[-1] not in _SENTENCE_ENDINGS
 
 
 def _fields(path: Path) -> dict:

--- a/scripts/reformat_raw_transcripts.py
+++ b/scripts/reformat_raw_transcripts.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Reflow stored raw transcripts into readable paragraphs.
+
+Transcripts written before `format_for_storage` existed are a single wall of
+text — the worst in this vault was one 53,259-word paragraph. This rewrites
+them in place, changing no words.
+
+    .venv/bin/python scripts/reformat_raw_transcripts.py --check   # report only
+    .venv/bin/python scripts/reformat_raw_transcripts.py
+
+Refuses to write any file whose text is not character-identical once whitespace
+is removed, so a formatting bug cannot quietly corrupt the archive.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+from project_paths import RAW_TRANSCRIPTS
+from transcript_sanitizer import format_for_storage
+from utils import read_text, write_text
+
+
+def _squash(text: str) -> str:
+    return re.sub(r"\s+", "", text)
+
+
+def _longest_paragraph(text: str) -> int:
+    return max((len(block.split()) for block in text.split("\n\n")), default=0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--check", action="store_true", help="Report what would change without writing")
+    args = parser.parse_args()
+
+    changed = skipped = 0
+    refused: list[str] = []
+    worst_before = worst_after = 0
+
+    for path in sorted(RAW_TRANSCRIPTS.glob("*.md")):
+        original = read_text(path)
+        head, sep, body = original.partition("\n---\n")
+        if not sep:  # no frontmatter; treat the whole file as body
+            head, body = "", original
+        # Keep the "# ... Raw Transcript" heading out of the reflow.
+        heading = ""
+        stripped = body.lstrip("\n")
+        if stripped.startswith("# "):
+            heading, _, stripped = stripped.partition("\n")
+        formatted = format_for_storage(stripped)
+
+        if _squash(stripped) != _squash(formatted):
+            refused.append(path.name)
+            continue
+
+        rebuilt = f"{head}{sep}\n{heading}\n\n{formatted}\n" if sep else f"{heading}\n\n{formatted}\n"
+        worst_before = max(worst_before, _longest_paragraph(stripped))
+        worst_after = max(worst_after, _longest_paragraph(formatted))
+
+        if rebuilt == original:
+            skipped += 1
+            continue
+        changed += 1
+        if not args.check:
+            write_text(path, rebuilt)
+
+    verb = "would change" if args.check else "reformatted"
+    print(f"{verb}: {changed} | already formatted: {skipped} | refused: {len(refused)}")
+    print(f"longest paragraph: {worst_before:,} words -> {worst_after:,} words")
+    for name in refused:
+        print(f"  REFUSED (text would change): {name}", file=sys.stderr)
+    return 1 if refused else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_transcript_sanitizer.py
+++ b/scripts/test_transcript_sanitizer.py
@@ -110,3 +110,60 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+
+def test_format_for_storage_changes_no_words() -> None:
+    """The invariant that matters: reflowing must never alter the text itself."""
+    raw = (
+        "One unbroken wall of speech that goes on and on. It has several sentences. "
+        "Each of them should survive intact. Even this one, with an aside — like so. "
+    ) * 40
+
+    formatted = transcript_sanitizer.format_for_storage(raw)
+
+    squash = lambda text: "".join(text.split())
+    assert squash(formatted) == squash(raw)
+
+
+def test_format_for_storage_breaks_a_wall_into_paragraphs() -> None:
+    raw = " ".join(f"Sentence number {n} says something." for n in range(200))
+
+    formatted = transcript_sanitizer.format_for_storage(raw)
+    paragraphs = formatted.split("\n\n")
+
+    assert len(paragraphs) > 5
+    assert max(len(p.split()) for p in paragraphs) <= 150
+
+
+def test_format_for_storage_does_not_invent_speakers() -> None:
+    """Measured across the vault, a loose `Name:` rule matched 36 false speakers
+    and zero real ones — section headings and mid-sentence colons. Only explicit
+    diarization markers may be labelled."""
+    raw = (
+        "Introduction: this is a heading, not a speaker.\n"
+        "My current advice to founders is: ship earlier than feels right.\n"
+    )
+
+    formatted = transcript_sanitizer.format_for_storage(raw)
+
+    assert "**Introduction:**" not in formatted
+    assert "**My current advice to founders is:**" not in formatted
+    assert "Introduction: this is a heading" in formatted
+
+
+def test_format_for_storage_keeps_explicit_speaker_markers() -> None:
+    raw = "Speaker_1: first turn here.\n\nSPEAKER 2: second turn here."
+
+    formatted = transcript_sanitizer.format_for_storage(raw)
+
+    assert "**Speaker_1:** first turn here." in formatted
+    assert "**SPEAKER 2:** second turn here." in formatted
+
+
+def test_format_for_storage_is_idempotent() -> None:
+    raw = " ".join(f"Sentence number {n} says something." for n in range(120))
+
+    once = transcript_sanitizer.format_for_storage(raw)
+    twice = transcript_sanitizer.format_for_storage(once)
+
+    assert once == twice

--- a/scripts/test_transcript_sanitizer.py
+++ b/scripts/test_transcript_sanitizer.py
@@ -167,3 +167,19 @@ def test_format_for_storage_is_idempotent() -> None:
     twice = transcript_sanitizer.format_for_storage(once)
 
     assert once == twice
+
+
+def test_clean_line_keeps_spoken_times() -> None:
+    """"2:00 a.m." is speech, not a timestamp. The old rule ate the "2:00"."""
+    assert transcript_sanitizer._clean_line("2:00 a.m. Wow, thanks for being on, Saad.") == (
+        "2:00 a.m. Wow, thanks for being on, Saad."
+    )
+    assert transcript_sanitizer._clean_line("9:30 pm and still going") == "9:30 pm and still going"
+
+
+def test_clean_line_still_strips_real_timestamps() -> None:
+    assert transcript_sanitizer._clean_line("[00:01] here we go") == "here we go"
+    assert transcript_sanitizer._clean_line("(1:02) here we go") == "here we go"
+    assert transcript_sanitizer._clean_line("00:01:02 here we go") == "here we go"
+    assert transcript_sanitizer._clean_line("02:30 here we go") == "here we go"
+    assert transcript_sanitizer._clean_line("00:02:03") == ""

--- a/scripts/test_transcript_sanitizer.py
+++ b/scripts/test_transcript_sanitizer.py
@@ -183,3 +183,16 @@ def test_clean_line_still_strips_real_timestamps() -> None:
     assert transcript_sanitizer._clean_line("00:01:02 here we go") == "here we go"
     assert transcript_sanitizer._clean_line("02:30 here we go") == "here we go"
     assert transcript_sanitizer._clean_line("00:02:03") == ""
+
+
+def test_looks_incomplete_flags_truncation_at_any_length() -> None:
+    import audit_knowledge_base as audit
+
+    long_cut_off = " ".join(["word"] * 3000) + " thanks for being here and"
+    short_complete = " ".join(["word"] * 180) + " lead the way."
+
+    assert audit._looks_incomplete(long_cut_off)          # 3000 words, still cut off
+    assert not audit._looks_incomplete(short_complete)    # 180 words, but finished
+    assert audit._looks_incomplete("")
+    assert audit._looks_incomplete("a stub of only a few words.")
+    assert not audit._looks_incomplete(" ".join(["word"] * 100) + ' he said "yes."')

--- a/scripts/transcript_sanitizer.py
+++ b/scripts/transcript_sanitizer.py
@@ -98,10 +98,28 @@ def format_for_storage(transcript: str, target_words: int = STORED_PARAGRAPH_WOR
     return "\n\n".join(out).strip()
 
 
+# A leading timestamp is only stripped when it cannot be speech. Bracketed
+# forms and zero-padded or hour:minute:second forms are machine-emitted; a bare
+# "2:00" with an unpadded hour is how a person says a time, and stripping it
+# turned "2:00 a.m. Wow, thanks for being on" into "a.m. Wow, thanks for being
+# on". Across 88 stored transcripts there were zero real leading timestamps and
+# one spoken time, so the loose rule only ever did damage here.
+_LEADING_TIMESTAMP = re.compile(
+    r"^(?:"
+    r"\[\d{1,2}:\d{2}(?::\d{2})?\]"          # [0:01] or [00:01:02]
+    r"|\(\d{1,2}:\d{2}(?::\d{2})?\)"         # (0:01)
+    r"|\d{1,2}:\d{2}:\d{2}"                   # 00:01:02
+    r"|\d{2}:\d{2}(?!\s*[ap]\.?m\.?\b)"     # 02:30, but not "02:30 pm"
+    r")\s*"
+)
+
+
 def _clean_line(line: str) -> str:
     line = re.sub(r"\s+", " ", line).strip()
-    line = re.sub(r"^(?:\[?\d{1,2}:\d{2}(?::\d{2})?\]?\s*)+", "", line).strip()
-    if re.fullmatch(r"\[?\d{1,2}:\d{2}(?::\d{2})?\]?", line):
+    while (stripped := _LEADING_TIMESTAMP.sub("", line, count=1)) != line:
+        line = stripped
+    line = line.strip()
+    if re.fullmatch(r"[\[(]?\d{1,2}:\d{2}(?::\d{2})?[\])]?", line):
         return ""
     return line
 

--- a/scripts/transcript_sanitizer.py
+++ b/scripts/transcript_sanitizer.py
@@ -55,6 +55,49 @@ def deterministic_cleanup(transcript: str) -> str:
     return "\n\n".join(paragraphs).strip()
 
 
+STORED_PARAGRAPH_WORDS = 90
+
+# Only unmistakable diarization markers. The general `Name:` heuristic used for
+# digest text is far too loose for stored transcripts: measured across the whole
+# vault it matched zero real speakers and 36 false ones — mid-sentence colons
+# ("My current advice to founders is:") and section headings ("Introduction:").
+# Gemini and Mistral both return undiarized prose, so labelling is nearly always
+# wrong here; recognise only the explicit forms and otherwise leave text alone.
+_EXPLICIT_SPEAKER = re.compile(r"^(speaker[ _-]?\d{1,2})\s*:\s*(.*)$", re.IGNORECASE)
+
+
+def format_for_storage(transcript: str, target_words: int = STORED_PARAGRAPH_WORDS) -> str:
+    """Reflow a transcript into readable paragraphs, changing no words.
+
+    Transcription returns either one unbroken block (Mistral) or one sentence
+    per line (Gemini). Markdown renders both as a single wall of text — the
+    worst in this vault was a 53,259-word paragraph. This regroups sentences
+    into paragraphs and preserves any blank-line structure the source had.
+    """
+    text = transcript.replace("\r\n", "\n").replace("\r", "\n")
+    blocks: list[list[str]] = [[]]
+    for raw_line in text.splitlines():
+        line = _clean_line(raw_line)
+        if not line:
+            if blocks[-1]:
+                blocks.append([])
+            continue
+        blocks[-1].append(line)
+
+    out: list[str] = []
+    for block in blocks:
+        if not block:
+            continue
+        speaker, first = _EXPLICIT_SPEAKER.match(block[0]).groups() if _EXPLICIT_SPEAKER.match(block[0]) else (None, None)
+        if speaker:
+            block = [first, *block[1:]] if first else block[1:]
+        paragraphs = _paragraphs_from_text(" ".join(block), target_words)
+        if speaker and paragraphs:
+            paragraphs[0] = f"**{speaker.strip()}:** {paragraphs[0]}"
+        out.extend(paragraphs)
+    return "\n\n".join(out).strip()
+
+
 def _clean_line(line: str) -> str:
     line = re.sub(r"\s+", " ", line).strip()
     line = re.sub(r"^(?:\[?\d{1,2}:\d{2}(?::\d{2})?\]?\s*)+", "", line).strip()
@@ -77,7 +120,7 @@ def _speaker_turn(line: str) -> tuple[str | None, str]:
     return speaker, match.group(2).strip()
 
 
-def _paragraphs_from_text(text: str) -> list[str]:
+def _paragraphs_from_text(text: str, target_words: int = 120) -> list[str]:
     if not text.strip():
         return []
     sentences = re.split(r"(?<=[.!?])\s+", text.strip())
@@ -86,7 +129,7 @@ def _paragraphs_from_text(text: str) -> list[str]:
     word_count = 0
     for sentence in sentences:
         words = sentence.split()
-        if current and word_count + len(words) > 120:
+        if current and word_count + len(words) > target_words:
             paragraphs.append(" ".join(current))
             current = []
             word_count = 0

--- a/scripts/transcript_store.py
+++ b/scripts/transcript_store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from obsidian_metadata import obsidian_aliases, yaml_list_block
 from project_paths import RAW_TRANSCRIPTS
 from sources import MediaItem
+from transcript_sanitizer import format_for_storage
 from utils import read_text, slugify, split_frontmatter, write_text, yaml_value
 
 
@@ -27,6 +28,10 @@ def write_raw_transcript(item: MediaItem, transcript: str, path: Path | None = N
         "aliases",
         obsidian_aliases(f"{item.title} raw transcript", item.title),
     )
+    # Transcription returns either one unbroken block or one sentence per line;
+    # Markdown renders both as a wall of text. Reflow into paragraphs on the way
+    # in. This changes no words — only where the line breaks fall.
+    transcript = format_for_storage(transcript)
     body = f"""---
 id: {yaml_value(item.id)}
 title: {yaml_value(f"{item.title} raw transcript")}

--- a/skills/ai-weekly-reads/SKILL.md
+++ b/skills/ai-weekly-reads/SKILL.md
@@ -13,7 +13,7 @@ Work from the AI Weekly Reads repository root.
 - `config/settings.example.json` is the shareable settings template; local `config/settings.json` is ignored by Git.
 - `inbox/links.example.txt` is the shareable inbox template; local `inbox/links.txt` is ignored by Git.
 - `inbox/links.txt` is for one-off links collected during the week.
-- `knowledge_base/raw_transcripts/` is the canonical local raw transcript/text store.
+- `knowledge_base/raw_transcripts/` is the canonical local raw transcript/text store. `write_raw_transcript` reflows text through `format_for_storage` before writing: transcription returns either one unbroken block (Mistral) or one sentence per line (Gemini), and Markdown renders both as a wall of text. The reflow changes no words — only line breaks — and refuses to label speakers except on explicit `Speaker N:` markers, because a looser rule matched 36 false speakers and zero real ones across the vault. Run `scripts/reformat_raw_transcripts.py` to backfill transcripts written before this existed.
 - `knowledge_base/resources/` is the canonical local clean reading-note store.
 - `knowledge_base/weekly_books/` stores local Markdown weekly books for Obsidian.
 - `knowledge_base/sources/`, `knowledge_base/people/`, `knowledge_base/topics/`, and `knowledge_base/indexes/` are generated local graph hubs. Resources link to source, speaker, and topic hubs; weekly books link to included resources. The default global graph shows only resources and topics.


### PR DESCRIPTION
## 1. Raw transcripts were a wall of text

Transcription returns one of two shapes, and Markdown renders both identically as a single block: **Mistral** returns one unbroken paragraph, **Gemini** returns one sentence per line, which Markdown joins back together.

| Before | |
|---|---|
| Transcripts with no paragraph break at all | 32 of 45 |
| Median longest paragraph | 3,143 words |
| Worst single paragraph | **53,259 words** (one entire podcast) |

`format_for_storage` regroups sentences into ~90-word paragraphs on write. After: 3,734 paragraphs, median 78 words, exactly one over 200 (an unpunctuated run that cannot be split without inventing sentence boundaries).

**Lossless, proven**: every transcript is character-identical to its original once whitespace is removed — 88/88.

### It deliberately does not reuse the digest's speaker detection

That rule labels any short line ending in a colon. Run against these transcripts it found **36 false speakers and zero real ones** — `**My current advice to founders is:**`, `**Introduction:**`. Gemini and Mistral both return undiarized prose, so only explicit `Speaker N:` markers are labelled.

## 2. The timestamp filter was eating spoken times

`_clean_line` stripped any leading `H:MM`:

```
2:00 a.m. Wow, thanks for being on, Saad.   →   a.m. Wow, thanks for being on, Saad.
```

This affected the **digest path too**, not just stored transcripts — `deterministic_cleanup` uses the same helper, so published editions were losing text.

Stripping is now limited to forms that cannot be speech: bracketed, parenthesised, `hour:minute:second`, or a zero-padded hour not followed by am/pm. Across all 88 transcripts there are zero real leading timestamps and exactly one spoken time, so the loose rule only ever did damage.

Found by `reformat_raw_transcripts.py`, which refuses to write any file whose text would change and named the offending file rather than corrupting it.

## 3. The tests were never run

`scripts/test_transcript_sanitizer.py` existed but nothing invoked it, and pytest was not a dependency — so a regression in transcript handling could reach the knowledge base unnoticed. Adds `requirements-dev.txt` and runs pytest and pyflakes in CI alongside the existing compile, health and audit steps.

## 4. The audit's short-transcript rule was wrong in both directions

**False positives, weekly.** It flagged two *complete* transcripts. Stanford Online posts genuine 1m12s and 1m33s clips; verified by video ID, those transcribe to 180 and 194 words — 125-150 words per minute, a normal speaking pace. A check that cries wolf every week teaches you to skip the audit output.

**And it missed the real failures.** Five transcripts of 1,800-4,300 words simply stop mid-sentence:

```
...one app with 3,000 flags. Yeah. And like, "Well, what are you working
...it to like draft emails, for example. Cool. All right, so those those
...Thank you for coming. I, again, uh Yeah, thanks for being here and
```

That is what a cut-off transcription looks like, and no length threshold could have caught it.

The rule is now: a stub, or text not ending on sentence-terminating punctuation, at any length. Clears the two false positives, surfaces the five real ones.

**Those five are pre-existing incomplete transcriptions, not something this PR introduces.** They are now visible; re-transcribing them is a separate decision.

## Verification

- Losslessness proven across the whole vault, 88/88 character-identical.
- 12 tests pass, covering losslessness, no-invented-speakers, idempotence, both timestamp cases, and truncation-at-any-length.
- Full CI pipeline re-run against a **clean checkout** where `knowledge_base/` is nearly empty — the case local testing cannot reach.
- `check_repo_health.py` and `audit_knowledge_base.py` pass.

## Backfill

`scripts/reformat_raw_transcripts.py` reflows already-stored transcripts. All 88 are done and pushed to the knowledge-base repo separately.
