### PR TITLE
Key YouTube items by video id so the same video isn't processed twice

### DIFF
--- a/scripts/sources.py
+++ b/scripts/sources.py
@@ -145,6 +145,27 @@ def _entry_published(entry: dict) -> str | None:
     return entry.get("published") or entry.get("updated")
 
 
+def youtube_item_id(url: str) -> str:
+    """Stable identity for a YouTube item.
+
+    Hashing the URL as it arrived makes the same video look like several
+    different items: a ``youtu.be`` share link, a ``watch?v=`` link from channel
+    discovery, a mobile ``m.youtube.com`` link and a timestamped ``&t=`` link all
+    point at one video but produce four ids. Each one is transcribed, summarized
+    and billed separately, and each shows up in the edition.
+
+    Podcast entries already avoid this by keying on the feed guid first
+    (``_entry_stable_key``); this is the YouTube equivalent. The video id is
+    namespaced so it cannot collide with a non-YouTube item that happens to hash
+    to the same value, and a URL we cannot parse falls back to the old behaviour
+    rather than losing its identity entirely.
+    """
+    video_id = youtube_video_id(url)
+    if not video_id:
+        return stable_id(url)
+    return stable_id(f"youtube:{video_id}")
+
+
 def _youtube_item(url: str) -> MediaItem:
     title = url
     description = None
@@ -177,7 +198,7 @@ def _youtube_item(url: str) -> MediaItem:
     except Exception as exc:
         print(f"Could not fetch YouTube metadata for {url}: {exc}")
     return MediaItem(
-        id=stable_id(url),
+        id=youtube_item_id(url),
         url=url,
         source_type="youtube",
         title=title,

--- a/scripts/test_youtube_item_id.py
+++ b/scripts/test_youtube_item_id.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from sources import youtube_item_id  # noqa: E402
+from utils import stable_id  # noqa: E402
+
+VIDEO_ID = "dQw4w9WgXcQ"
+
+EQUIVALENT_URLS = [
+    f"https://www.youtube.com/watch?v={VIDEO_ID}",
+    f"https://youtube.com/watch?v={VIDEO_ID}",
+    f"https://m.youtube.com/watch?v={VIDEO_ID}",
+    f"https://youtu.be/{VIDEO_ID}",
+    f"https://www.youtube.com/watch?v={VIDEO_ID}&t=42s",
+    f"https://www.youtube.com/watch?v={VIDEO_ID}&list=PLabc123",
+    f"https://www.youtube.com/embed/{VIDEO_ID}",
+    f"https://www.youtube.com/shorts/{VIDEO_ID}",
+    f"https://www.youtube.com/live/{VIDEO_ID}",
+]
+
+
+def test_equivalent_youtube_urls_share_one_id():
+    ids = {youtube_item_id(url) for url in EQUIVALENT_URLS}
+    assert len(ids) == 1, f"expected one id, got {len(ids)}: {sorted(ids)}"
+
+
+def test_share_link_matches_channel_discovery_link():
+    # The duplicate people actually hit: a link pasted into inbox/links.txt
+    # against the watch?v= URL channel discovery produces for the same video.
+    assert youtube_item_id(f"https://youtu.be/{VIDEO_ID}") == youtube_item_id(
+        f"https://www.youtube.com/watch?v={VIDEO_ID}"
+    )
+
+
+def test_timestamp_and_playlist_params_do_not_change_identity():
+    base = youtube_item_id(f"https://www.youtube.com/watch?v={VIDEO_ID}")
+    assert youtube_item_id(f"https://www.youtube.com/watch?v={VIDEO_ID}&t=42s") == base
+    assert youtube_item_id(f"https://www.youtube.com/watch?v={VIDEO_ID}&list=PLabc") == base
+
+
+def test_different_videos_keep_different_ids():
+    assert youtube_item_id(f"https://youtu.be/{VIDEO_ID}") != youtube_item_id(
+        "https://youtu.be/oHg5SJYRHA0"
+    )
+
+
+def test_non_youtube_url_falls_back_to_url_hash():
+    url = "https://example.com/some/episode"
+    assert youtube_item_id(url) == stable_id(url)
+
+
+def test_youtube_id_is_namespaced_against_raw_video_id_hash():
+    # Guards against a non-YouTube item whose URL happens to be the bare video id.
+    assert youtube_item_id(f"https://youtu.be/{VIDEO_ID}") != stable_id(VIDEO_ID)


### PR DESCRIPTION
Fixes #16.

Really enjoyed reading through this codebase — the guid-first podcast keying in `_entry_stable_key()` is exactly the right instinct, and this change just extends the same idea to YouTube.

## The problem

`_youtube_item()` built its id from `stable_id(url)`, a hash of the URL as it arrived. One video reaching the pipeline under different URL forms produced different ids:

```
  id=0424974c68530290   https://www.youtube.com/watch?v=dQw4w9WgXcQ
  id=61e610a9d7fd37bc   https://youtu.be/dQw4w9WgXcQ
  id=5c1b906c65c733d2   https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s
  id=71c5a3c2ade54326   https://m.youtube.com/watch?v=dQw4w9WgXcQ
```

Nothing downstream treats those as the same item — `find_resource()`, `find_raw_transcript()` and the `seen_item_ids` set in `discover_items()` all key off `item.id`. So the video is transcribed and summarized again, appears more than once in an edition, and costs another model call each time.

The realistic trigger is a `youtu.be` share link pasted into `inbox/links.txt` alongside the `watch?v=` URL channel discovery produces for the same video.

## The change

A small `youtube_item_id()` helper in `sources.py`:

```python
def youtube_item_id(url: str) -> str:
    video_id = youtube_video_id(url)
    if not video_id:
        return stable_id(url)
    return stable_id(f"youtube:{video_id}")
```

- Uses the existing `youtube_video_id()` from `utils`, which already handles `watch?v=`, `youtu.be`, `shorts`, `embed` and `live`.
- Namespaces as `youtube:<id>` so a canonical id can't collide with a non-YouTube item that happens to hash the same way.
- Falls back to the old behaviour when no video id parses, so nothing loses its identity.

Only `_youtube_item()` changes — every YouTube item funnels through `resolve_link()`, so it's a single call site.

## Tests

Six new tests in `scripts/test_youtube_item_id.py`, covering the nine equivalent URL forms, the share-link-vs-discovery case specifically, `&t=`/`&list=` params, different videos staying distinct, the non-YouTube fallback, and the namespacing guard.

```
18 passed
```

Full CI sequence run locally — `py_compile`, `pyflakes`, `pytest`, `check_repo_health.py`, `audit_knowledge_base.py` — all clean.

## One thing to decide before merging

This re-keys YouTube items, so videos already in the knowledge base will look new on the next run and be re-summarized once.

Options, depending on what you'd prefer:

1. **Merge as-is** — one noisy run, then correct forever. Simplest, costs a batch of model calls.
2. **One-shot migration script** — rewrite the `id:` frontmatter in `resources/` and raw transcripts from old id to new before the next run. No reprocessing.
3. **Legacy-id fallback in the lookups** — have `find_resource()` / `find_raw_transcript()` also try `stable_id(item.url)`, self-healing on next write. Most seamless, touches the most code.

I left it at (1) to keep the diff focused, but I'm happy to add (2) or (3) to this PR — just say which you'd rather have.
