### PR TITLE
Cap dependencies at the major version and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      # One PR for routine patch/minor bumps; majors still arrive separately so
+      # they get looked at on their own.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
           cache: pip
 
       # The health scripts run on a bare interpreter; this step exists to
-      # catch requirement pins that no longer resolve.
+      # catch a dependency set that no longer resolves or imports. Runtime
+      # requirements are capped at the major version so a breaking release
+      # cannot land here on its own -- see requirements.txt.
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest>=8.0
-pyflakes>=3.0
+pytest>=8.0,<9
+pyflakes>=3.0,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,16 @@
-beautifulsoup4>=4.12.0
-feedparser>=6.0.0
-google-api-python-client>=2.130.0
-google-auth-httplib2>=0.2.0
-google-auth-oauthlib>=1.2.0
-google-genai>=2.20.0
-mistralai>=2.4.0
-requests>=2.31.0
-youtube-transcript-api>=0.6.0
+# Upper bounds cap the major version so a scheduled run cannot pick up a
+# breaking release on its own. Floors are unchanged.
+#
+# yt-dlp is deliberately left uncapped: it tracks YouTube's frequent extractor
+# changes, and an old pin is the failure mode here rather than the fix. It still
+# needs a floor so a stale resolver cannot fall far behind.
+beautifulsoup4>=4.12.0,<5
+feedparser>=6.0.0,<7
+google-api-python-client>=2.130.0,<3
+google-auth-httplib2>=0.2.0,<1
+google-auth-oauthlib>=1.2.0,<2
+google-genai>=2.20.0,<3
+mistralai>=2.4.0,<3
+requests>=2.31.0,<3
+youtube-transcript-api>=0.6.0,<2
 yt-dlp>=2024.1.0


### PR DESCRIPTION
Closes #17.

## What this does

Every runtime dependency now carries an upper bound on the major version. Floors are unchanged, so nothing that resolves today stops resolving — this only stops a *new major* from landing on a scheduled run without anyone looking at it.

```diff
-beautifulsoup4>=4.12.0
+beautifulsoup4>=4.12.0,<5
-mistralai>=2.4.0
+mistralai>=2.4.0,<3
-youtube-transcript-api>=0.6.0
+youtube-transcript-api>=0.6.0,<2
```

**`yt-dlp` is deliberately left uncapped.** It tracks YouTube's extractor changes, so pinning it is the failure mode rather than the fix — an old `yt-dlp` simply stops working. It keeps its floor so a resolver can't fall far behind. I put a comment in the file explaining this so it doesn't look like an oversight later.

## The case that already happened

`youtube-transcript-api` has a floor of `>=0.6.0`, but `1.2.4` is what installs today, and 1.0 changed the API. `scripts/transcription/youtube.py` already handles it:

```python
if hasattr(YouTubeTranscriptApi, "get_transcript"):
    transcript = YouTubeTranscriptApi.get_transcript(video_id)
else:
    transcript = YouTubeTranscriptApi().fetch(video_id)
```

That shim is this exact problem, solved after the fact. The cap means the next one gets caught in a PR instead of in a Monday morning.

## Dependabot

Added `.github/dependabot.yml` — weekly, patch/minor grouped into one PR, majors arriving separately so they get individual attention. Bumps then run CI before they can affect a real run.

## CI comment

The install step said:

> this step exists to catch requirement pins that no longer resolve

With floor-only constraints it couldn't — the resolver always found something. Updated to describe what it now does.

## Verified

- `pip install --dry-run` resolves cleanly under the new constraints
- Resolved set is unchanged from today's: `mistralai==2.10.0`, `youtube-transcript-api==1.2.4`, `google-genai==2.23.0`, etc.
- Both YAML files parse
- `pytest` — 12 passed

## Note

I went with caps + Dependabot rather than a full lockfile (option 2 in the issue). A lockfile is stricter, but it's a much larger diff, needs a regeneration step in the workflow, and pins transitive deps you may not want frozen. Happy to switch to that if you'd prefer — the tradeoff is reproducibility against maintenance overhead.
