### PR TITLE
Add tests for source parsing and the discovery filter

### DIFF
--- a/scripts/test_pipeline_add_item.py
+++ b/scripts/test_pipeline_add_item.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pipeline
+from sources import MediaItem
+
+
+def _item(item_id: str = "id-1", published: str | None = "2026-09-05") -> MediaItem:
+    return MediaItem(
+        id=item_id,
+        url=f"https://example.com/{item_id}",
+        source_type="podcast",
+        title=f"Episode {item_id}",
+        origin="https://feed.example.com/rss",
+        published=published,
+    )
+
+
+def _settings(max_items_per_run: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(max_items_per_run=max_items_per_run)
+
+
+def _stats() -> pipeline.RunStats:
+    return pipeline.RunStats()
+
+
+def _add(item, *, cutoff=None, settings=None, items=None, seen=None, **kwargs):
+    items = [] if items is None else items
+    seen = set() if seen is None else seen
+    stats = kwargs.pop("stats", None) or _stats()
+    added = pipeline._add_item(
+        item,
+        settings or _settings(),
+        cutoff,
+        stats,
+        items,
+        seen,
+        **kwargs,
+    )
+    return added, items, stats
+
+
+# --- publication window -----------------------------------------------------
+
+def test_item_inside_the_window_is_kept() -> None:
+    added, items, _ = _add(
+        _item(published="2026-09-05"),
+        cutoff=date(2026, 9, 1),
+        filter_by_publication_window=True,
+    )
+
+    assert added is True
+    assert len(items) == 1
+
+
+def test_item_before_the_cutoff_is_dropped() -> None:
+    added, items, stats = _add(
+        _item(published="2026-08-20"),
+        cutoff=date(2026, 9, 1),
+        filter_by_publication_window=True,
+    )
+
+    assert added is False
+    assert items == []
+    assert stats.skipped_outside_window == 1
+
+
+def test_the_cutoff_day_itself_is_inside_the_window() -> None:
+    # Boundary: the filter is `published < cutoff`, so an item published exactly
+    # on the cutoff belongs to the edition rather than the one before it.
+    added, items, _ = _add(
+        _item(published="2026-09-01"),
+        cutoff=date(2026, 9, 1),
+        filter_by_publication_window=True,
+    )
+
+    assert added is True
+    assert len(items) == 1
+
+
+def test_window_is_not_applied_when_filtering_is_off() -> None:
+    added, items, _ = _add(
+        _item(published="2020-01-01"),
+        cutoff=date(2026, 9, 1),
+        filter_by_publication_window=False,
+    )
+
+    assert added is True
+    assert len(items) == 1
+
+
+def test_no_cutoff_means_no_window_filtering() -> None:
+    added, _items, _ = _add(
+        _item(published="2020-01-01"),
+        cutoff=None,
+        filter_by_publication_window=True,
+    )
+
+    assert added is True
+
+
+# --- missing publication dates ----------------------------------------------
+
+def test_undated_item_is_kept_when_a_date_is_not_required() -> None:
+    added, items, stats = _add(
+        _item(published=None),
+        cutoff=date(2026, 9, 1),
+        filter_by_publication_window=True,
+        require_publication_date=False,
+    )
+
+    assert added is True
+    assert len(items) == 1
+    assert stats.skipped_missing_date == 0
+
+
+def test_undated_item_is_dropped_when_a_date_is_required() -> None:
+    # Channel discovery sets require_publication_date, so an item whose date
+    # cannot be resolved does not silently join whatever edition is building.
+    added, items, stats = _add(
+        _item(published=None),
+        cutoff=date(2026, 9, 1),
+        filter_by_publication_window=True,
+        require_publication_date=True,
+    )
+
+    assert added is False
+    assert items == []
+    assert stats.skipped_missing_date == 1
+
+
+def test_unparseable_date_counts_as_missing() -> None:
+    added, _items, stats = _add(
+        _item(published="sometime last week"),
+        cutoff=date(2026, 9, 1),
+        filter_by_publication_window=True,
+        require_publication_date=True,
+    )
+
+    assert added is False
+    assert stats.skipped_missing_date == 1
+
+
+# --- dedup ------------------------------------------------------------------
+
+def test_an_already_seen_id_is_not_added_twice() -> None:
+    items: list[MediaItem] = []
+    seen: set[str] = set()
+
+    first, items, _ = _add(_item("dup"), items=items, seen=seen, filter_by_publication_window=False)
+    second, items, _ = _add(_item("dup"), items=items, seen=seen, filter_by_publication_window=False)
+
+    assert first is True
+    assert second is False
+    assert len(items) == 1
+
+
+def test_distinct_ids_are_both_added() -> None:
+    items: list[MediaItem] = []
+    seen: set[str] = set()
+
+    _add(_item("a"), items=items, seen=seen, filter_by_publication_window=False)
+    _add(_item("b"), items=items, seen=seen, filter_by_publication_window=False)
+
+    assert len(items) == 2
+
+
+# --- per-run limit ----------------------------------------------------------
+
+def test_run_limit_stops_further_items() -> None:
+    items: list[MediaItem] = []
+    seen: set[str] = set()
+    settings = _settings(max_items_per_run=2)
+
+    results = [
+        _add(_item(f"i{n}"), settings=settings, items=items, seen=seen,
+             filter_by_publication_window=False)[0]
+        for n in range(4)
+    ]
+
+    assert results == [True, True, False, False]
+    assert len(items) == 2
+
+
+def test_zero_limit_means_unlimited() -> None:
+    items: list[MediaItem] = []
+    seen: set[str] = set()
+    settings = _settings(max_items_per_run=0)
+
+    for n in range(5):
+        _add(_item(f"i{n}"), settings=settings, items=items, seen=seen,
+             filter_by_publication_window=False)
+
+    assert len(items) == 5

--- a/scripts/test_sources.py
+++ b/scripts/test_sources.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import sources
+
+
+# --- read_inbox -------------------------------------------------------------
+
+def test_read_inbox_skips_comments_and_blank_lines(tmp_path) -> None:
+    inbox = tmp_path / "links.txt"
+    inbox.write_text(
+        "# a comment\n"
+        "\n"
+        "https://example.com/one\n"
+        "   \n"
+        "  https://example.com/two  \n"
+        "# trailing comment\n",
+        encoding="utf-8",
+    )
+
+    assert sources.read_inbox(inbox, []) == [
+        "https://example.com/one",
+        "https://example.com/two",
+    ]
+
+
+def test_read_inbox_tolerates_a_utf8_bom(tmp_path) -> None:
+    # Files saved by some Windows editors start with a BOM; without utf-8-sig
+    # the first link silently becomes "﻿https://..." and never matches.
+    inbox = tmp_path / "links.txt"
+    inbox.write_text("https://example.com/one\n", encoding="utf-8-sig")
+
+    assert sources.read_inbox(inbox, []) == ["https://example.com/one"]
+
+
+def test_read_inbox_appends_configured_feeds_and_dedupes(tmp_path) -> None:
+    inbox = tmp_path / "links.txt"
+    inbox.write_text("https://example.com/one\nhttps://example.com/two\n", encoding="utf-8")
+
+    links = sources.read_inbox(inbox, ["https://example.com/two", "https://example.com/three"])
+
+    # Order preserved, inbox first, duplicate dropped.
+    assert links == [
+        "https://example.com/one",
+        "https://example.com/two",
+        "https://example.com/three",
+    ]
+
+
+def test_read_inbox_handles_a_missing_file(tmp_path) -> None:
+    assert sources.read_inbox(tmp_path / "nope.txt", ["https://example.com/feed"]) == [
+        "https://example.com/feed"
+    ]
+
+
+# --- _entry_stable_key ------------------------------------------------------
+
+def test_entry_stable_key_prefers_the_feed_guid() -> None:
+    entry = {
+        "id": "guid-123",
+        "link": "https://example.com/ep1?utm_source=rss",
+        "title": "Episode 1",
+    }
+
+    assert sources._entry_stable_key(entry, "https://cdn.example.com/1.mp3", "https://feed") == "guid-123"
+
+
+def test_entry_stable_key_survives_a_changing_link() -> None:
+    # The point of keying on the guid: a publisher rewriting its URLs must not
+    # make every past episode look new.
+    before = {"id": "guid-123", "link": "https://old.example.com/ep1"}
+    after = {"id": "guid-123", "link": "https://new.example.com/2026/ep1"}
+
+    assert sources._entry_stable_key(before, None, "https://feed") == sources._entry_stable_key(
+        after, None, "https://feed"
+    )
+
+
+def test_entry_stable_key_falls_back_through_link_then_audio() -> None:
+    link_only = {"link": "https://example.com/ep1"}
+    assert sources._entry_stable_key(link_only, "https://cdn/1.mp3", "https://feed") == "https://example.com/ep1"
+
+    audio_only: dict = {}
+    assert sources._entry_stable_key(audio_only, "https://cdn/1.mp3", "https://feed") == "https://cdn/1.mp3"
+
+
+def test_entry_stable_key_last_resort_is_feed_scoped() -> None:
+    entry = {"title": "Episode 1", "published": "2026-09-01"}
+
+    key = sources._entry_stable_key(entry, None, "https://feed.example.com/rss")
+
+    # Two shows can both have an "Episode 1"; the feed url keeps them apart.
+    assert key.startswith("https://feed.example.com/rss")
+    other = sources._entry_stable_key(entry, None, "https://other.example.com/rss")
+    assert key != other
+
+
+# --- _entry_published -------------------------------------------------------
+
+def test_entry_published_prefers_the_parsed_struct() -> None:
+    entry = {
+        "published_parsed": (2026, 9, 1, 13, 30, 0, 0, 0, 0),
+        "published": "whatever the string said",
+    }
+
+    assert sources._entry_published(entry) == "2026-09-01"
+
+
+def test_entry_published_falls_back_to_updated_struct() -> None:
+    entry = {"updated_parsed": (2026, 8, 15, 0, 0, 0, 0, 0, 0)}
+
+    assert sources._entry_published(entry) == "2026-08-15"
+
+
+def test_entry_published_returns_raw_string_when_unparsed() -> None:
+    assert sources._entry_published({"published": "Mon, 01 Sep 2026 13:30:00 +0000"}) == (
+        "Mon, 01 Sep 2026 13:30:00 +0000"
+    )
+
+
+def test_entry_published_is_none_when_absent() -> None:
+    assert sources._entry_published({}) is None
+
+
+# --- _looks_like_media_url --------------------------------------------------
+
+def test_looks_like_media_url_matches_audio_and_video_extensions() -> None:
+    for url in (
+        "https://cdn.example.com/ep1.mp3",
+        "https://cdn.example.com/ep1.M4A",
+        "https://cdn.example.com/clip.mp4",
+        "https://cdn.example.com/clip.webm",
+    ):
+        assert sources._looks_like_media_url(url), url
+
+
+def test_looks_like_media_url_ignores_query_strings() -> None:
+    assert sources._looks_like_media_url("https://cdn.example.com/ep1.mp3?token=abc&t=12")
+
+
+def test_looks_like_media_url_rejects_pages() -> None:
+    for url in (
+        "https://example.com/episode",
+        "https://example.com/episode.html",
+        "https://example.com/mp3",
+    ):
+        assert not sources._looks_like_media_url(url), url
+
+
+# --- resolve_link routing ---------------------------------------------------
+
+def test_resolve_link_rejects_non_urls() -> None:
+    assert sources.resolve_link("not a url") == []
+    assert sources.resolve_link("ftp://example.com/file.mp3") == []
+
+
+def test_resolve_link_routes_spotify_without_fetching() -> None:
+    items = sources.resolve_link("https://open.spotify.com/episode/abc123")
+
+    assert len(items) == 1
+    assert items[0].source_type == "spotify"
+
+
+def test_resolve_link_routes_a_bare_media_url() -> None:
+    items = sources.resolve_link("https://cdn.example.com/ep1.mp3?token=abc")
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.source_type == "direct_media"
+    assert item.audio_url == "https://cdn.example.com/ep1.mp3?token=abc"
+    # Title comes from the filename, with the query string stripped.
+    assert item.title == "ep1.mp3"


### PR DESCRIPTION
Towards #18, and a follow-on to the "run the tests in CI" change in #14.

**No production code changes** — this is tests only.

## What's covered

**`sources.py`**

- `read_inbox()` — comment and blank-line skipping, whitespace trimming, UTF-8 BOM tolerance, configured-feed append order, dedup, missing file
- `_entry_stable_key()` — guid preferred over link, the fallback chain (`id` → `guid` → `link` → audio → feed-scoped composite), and specifically that a publisher rewriting its URLs doesn't make every past episode look new
- `_entry_published()` — `published_parsed` preferred over the raw string, `updated_parsed` fallback, unparsed strings passed through, `None` when absent
- `_looks_like_media_url()` — extension matching, case insensitivity, query strings ignored, pages rejected
- `resolve_link()` — the routing branches that don't touch the network (rejects non-URLs, Spotify, bare media URLs)

**`pipeline.py` — `_add_item()`**

This is the decision table that determines whether an item joins an edition:

- Inside/outside the publication window
- **The boundary day itself** — the filter is `published < cutoff`, so an item published exactly on the cutoff belongs to this edition, not the previous one
- Undated items with `require_publication_date` both on and off
- Unparseable dates treated as missing
- Id dedup across calls
- `max_items_per_run`, including `0` meaning unlimited

## Why these two

They're where a wrong answer is silent. An item quietly excluded from an edition looks identical to a week with nothing new — there's no error, no missing file, just an absence nobody notices. Both are pure functions over plain inputs, so the tests are fast and need no fixtures or network.

## Verified they actually catch regressions

Rather than just checking they pass, I mutated the source and confirmed each failure lands on the right test:

| Mutation | Result |
|---|---|
| window boundary `<` → `<=` | `test_the_cutoff_day_itself_is_inside_the_window` fails |
| drop guid preference in `_entry_stable_key` | `test_entry_stable_key_survives_a_changing_link` fails |
| `utf-8-sig` → `utf-8` in `read_inbox` | `test_read_inbox_tolerates_a_utf8_bom` fails |

Source restored after each. Full suite: **42 passed** (12 existing + 30 new).

`py_compile`, `pyflakes`, `check_repo_health.py` and `audit_knowledge_base.py` all clean.

## Note

I used `SimpleNamespace` for `Settings` in the pipeline tests, matching the approach already in `test_transcript_sanitizer.py`, so the tests don't need the full config machinery. Happy to switch to real `Settings` objects if you'd rather they exercise that too.

I deliberately left `resolve_link()`'s YouTube branch untested here — it calls `yt_dlp` for metadata, so testing it properly means either network or a fair bit of mocking. Worth doing, but it felt like a separate change.
